### PR TITLE
sync src/ata_id/ata_id.c 

### DIFF
--- a/src/ata_id/ata_id.c
+++ b/src/ata_id/ata_id.c
@@ -183,7 +183,8 @@ static int disk_identify_command(int          fd,
                         return ret;
         }
 
-        if (!(sense[0] == 0x72 && desc[0] == 0x9 && desc[1] == 0x0c)) {
+        if (!(sense[0] == 0x72 && desc[0] == 0x9 && desc[1] == 0x0c) &&
+                !(sense[0] == 0x70 && sense[12] == 0x00 && sense[13] == 0x1d)) {
                 errno = EIO;
                 return -1;
         }


### PR DESCRIPTION
Author: Ryan Attard <frontrunner4000@gmail.com>

ata_id: Add support for host managed zone block devices (#14933)

If the peripheral device type is that of a host managed zone block device (0x14),
the device supports the same identification mechanisms as conventional disks (0x00).

systemd-commit: 06654d1225157ef2031559e47109730111514be2