### PR TITLE
Add getrandom(2) system call number for PowerPC

### DIFF
--- a/src/shared/missing.h
+++ b/src/shared/missing.h
@@ -57,6 +57,8 @@
 #    define __NR_getrandom 352
 #  elif defined(__s390x__)
 #    define __NR_getrandom 349
+#  elif defined(__powerpc__)
+#    define __NR_getrandom 359
 #  else
 #    warning "__NR_getrandom unknown for your architecture"
 #    define __NR_getrandom 0xffffffff


### PR DESCRIPTION
This is for both 32-bit and 64-bit targets.