### PR TITLE
rules/50-udev-default.rules: add PTP entry for Hyper-V/Azure

### DIFF
--- a/rules/50-udev-default.rules
+++ b/rules/50-udev-default.rules
@@ -83,4 +83,6 @@ KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"
 
 SUBSYSTEM=="ptp", ATTR{clock_name}=="KVM virtual PTP", SYMLINK += "ptp_kvm"
 
+SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK += "ptp_hyperv"
+
 LABEL="default_end"


### PR DESCRIPTION
udev rules: add rule to create /dev/ptp_hyperv

As for the KVM case, necessary for network cards with
PTP devices when running a guest on HyperV

systemd-commit: 32e868f058da8b90add00b2958c516241c532b70
Author: Luca Boccassi <luca.boccassi@microsoft.com>
Date:   Fri Feb 26 10:25:31 2021 +0000