### PR TITLE
udev: add udev_dir as synonym of udevdir

### DIFF
--- a/src/udev/udev.pc.in
+++ b/src/udev/udev.pc.in
@@ -3,4 +3,5 @@ Description: eudev
 Version: @UDEV_VERSION@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
-udevdir=@udevlibexecdir@
+udev_dir=@udevlibexecdir@
+udevdir=${udev_dir}


### PR DESCRIPTION
In systemd-udev `udevdir` was deprecated in favor of `udev_dir`.
This causes issues with the [latest release of upower](https://gitlab.freedesktop.org/upower/upower/-/blob/v0.99.17/meson.build#L91-95), which now checks for `udev_dir`, which is not provided by eudev.
This just adds `udev_dir`.

See here:
https://github.com/systemd/systemd/commit/4908de44b0a0409f84a7cdc5641b114d6ce8ba03

Please let me know if there are any issues.