### PR TITLE
Fix warnings detected by fortified builds

### DIFF
--- a/src/collect/collect.c
+++ b/src/collect/collect.c
@@ -94,12 +94,16 @@ static void usage(void)
  */
 static int prepare(char *dir, char *filename)
 {
-        char buf[512];
+        char buf[UTIL_PATH_SIZE + 1];
         int r, fd;
 
         r = mkdir(dir, 0700);
         if (r < 0 && errno != EEXIST)
                 return -errno;
+
+        /* Refuse to write to a truncated file path */
+        if (strlen(buf) + 1 + strlen(filename) > sizeof buf - 1)
+                return -1;
 
         snprintf(buf, sizeof(buf), "%s/%s", dir, filename);
 

--- a/src/collect/collect.c
+++ b/src/collect/collect.c
@@ -112,7 +112,8 @@ static int prepare(char *dir, char *filename)
                         fprintf(stderr, "Lock taken, wait for %d seconds\n", UDEV_ALARM_TIMEOUT);
                 if (errno == EAGAIN || errno == EACCES) {
                         alarm(UDEV_ALARM_TIMEOUT);
-                        lockf(fd, F_LOCK, 0);
+                        if (lockf(fd, F_LOCK, 0)) { /* TODO: implement proper error handling */
+                        }
                         if (debug)
                                 fprintf(stderr, "Acquired lock on %s\n", buf);
                 } else {
@@ -484,10 +485,12 @@ int main(int argc, char **argv)
         kickout();
 
         lseek(fd, 0, SEEK_SET);
-        ftruncate(fd, 0);
+        if (ftruncate(fd, 0)) { /* TODO: implement proper error handling */
+        }
         ret = missing(fd);
 
-        lockf(fd, F_ULOCK, 0);
+        if (lockf(fd, F_ULOCK, 0)) { /* TODO: implement proper error handling */
+        }
         close(fd);
 out:
         if (debug)

--- a/src/udev/udev-builtin-hwdb.c
+++ b/src/udev/udev-builtin-hwdb.c
@@ -76,8 +76,12 @@ static const char *modalias_usb(struct udev_device *dev, char *s, size_t size) {
         vn = strtol(v, NULL, 16);
         if (vn <= 0)
                 return NULL;
+        if (vn > 0xffff)
+                return NULL;
         pn = strtol(p, NULL, 16);
         if (pn <= 0)
+                return NULL;
+        if (pn > 0xffff)
                 return NULL;
         snprintf(s, size, "usb:v%04Xp%04X*", vn, pn);
         return s;

--- a/src/udev/udev-ctrl.c
+++ b/src/udev/udev-ctrl.c
@@ -262,7 +262,7 @@ static int ctrl_send(struct udev_ctrl *uctrl, enum udev_ctrl_msg_type type, int 
         int err = 0;
 
         memzero(&ctrl_msg_wire, sizeof(struct udev_ctrl_msg_wire));
-        strcpy(ctrl_msg_wire.version, "udev-" VERSION);
+        sprintf(ctrl_msg_wire.version, "%.*s", (int)(sizeof ctrl_msg_wire.version - 1), "udev-" VERSION);
         ctrl_msg_wire.magic = UDEV_CTRL_MAGIC;
         ctrl_msg_wire.type = type;
 


### PR DESCRIPTION
- do not overwrite memory (-pre versions trigger this)
- do not use truncated strings
- kill the warnings for unused result