### PR TITLE
Avoid warning on 32bit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,6 @@ AC_CHECK_SIZEOF(pid_t)
 AC_CHECK_SIZEOF(uid_t)
 AC_CHECK_SIZEOF(gid_t)
 AC_CHECK_SIZEOF(dev_t)
-AC_CHECK_SIZEOF(long)
 AC_CHECK_SIZEOF(time_t)
 AC_CHECK_SIZEOF(rlim_t,,[[
 #include <sys/time.h>

--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,6 @@ AC_CHECK_SIZEOF(pid_t)
 AC_CHECK_SIZEOF(uid_t)
 AC_CHECK_SIZEOF(gid_t)
 AC_CHECK_SIZEOF(dev_t)
-AC_CHECK_SIZEOF(time_t)
 AC_CHECK_SIZEOF(rlim_t,,[[
 #include <sys/time.h>
 #include <sys/resource.h>]])

--- a/configure.ac
+++ b/configure.ac
@@ -79,6 +79,7 @@ AC_CHECK_SIZEOF(pid_t)
 AC_CHECK_SIZEOF(uid_t)
 AC_CHECK_SIZEOF(gid_t)
 AC_CHECK_SIZEOF(dev_t)
+AC_CHECK_SIZEOF(long)
 AC_CHECK_SIZEOF(time_t)
 AC_CHECK_SIZEOF(rlim_t,,[[
 #include <sys/time.h>

--- a/src/shared/formats-util.h
+++ b/src/shared/formats-util.h
@@ -49,7 +49,11 @@
 #if SIZEOF_TIME_T == 8
 #  define PRI_TIME PRIi64
 #elif SIZEOF_TIME_T == 4
-#  define PRI_TIME PRIu32
+#    if SIZEOF_LONG == 4
+#      define PRI_TIME "lu"
+#    else
+#      define PRI_TIME PRIu32
+#    endif
 #else
 #  error Unknown time_t size
 #endif

--- a/src/shared/formats-util.h
+++ b/src/shared/formats-util.h
@@ -49,11 +49,7 @@
 #if SIZEOF_TIME_T == 8
 #  define PRI_TIME PRIi64
 #elif SIZEOF_TIME_T == 4
-#    if SIZEOF_LONG == 4
-#      define PRI_TIME "lu"
-#    else
-#      define PRI_TIME PRIu32
-#    endif
+#  define PRI_TIME PRIu32
 #else
 #  error Unknown time_t size
 #endif

--- a/src/shared/formats-util.h
+++ b/src/shared/formats-util.h
@@ -46,14 +46,6 @@
 #  error Unknown gid_t size
 #endif
 
-#if SIZEOF_TIME_T == 8
-#  define PRI_TIME PRIi64
-#elif SIZEOF_TIME_T == 4
-#  define PRI_TIME PRIu32
-#else
-#  error Unknown time_t size
-#endif
-
 #if SIZEOF_RLIM_T == 8
 #  define RLIM_FMT "%" PRIu64
 #elif SIZEOF_RLIM_T == 4

--- a/src/udev/udevadm-monitor.c
+++ b/src/udev/udevadm-monitor.c
@@ -46,9 +46,9 @@ static void print_device(struct udev_device *device, const char *source, int pro
         struct timespec ts;
 
         clock_gettime(CLOCK_MONOTONIC, &ts);
-        printf("%-6s[%"PRI_TIME".%06ld] %-8s %s (%s)\n",
+        printf("%-6s[%"PRIi64".%06ld] %-8s %s (%s)\n",
                source,
-               ts.tv_sec, ts.tv_nsec/1000,
+               (int64_t)ts.tv_sec, ts.tv_nsec/1000,
                udev_device_get_action(device),
                udev_device_get_devpath(device),
                udev_device_get_subsystem(device));


### PR DESCRIPTION
On 32bit arches where time_t is defined as long int and where
sizeof(long)==sizeof(int), PRI_TIME is PRIu32 which is "u" and gcc warns about
ignoring the long part of the integer type. There is no problem besides the
warning.

Use "lu" in the above conditions and PRIu32 in all other 32bit time_t cases.

````
udevadm-monitor.c: In function ‘print_device’:
udevadm-monitor.c:49:16: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 3 has type ‘__time_t’ {aka ‘long int’} [-Wformat=]
   49 |         printf("%-6s[%"PRI_TIME".%06ld] %-8s %s (%s)\n",
      |                ^~~~~~~~
   50 |                source,
   51 |                ts.tv_sec, ts.tv_nsec/1000,
      |                ~~~~~~~~~
      |                  |
      |                  __time_t {aka long int}
In file included from ../../src/shared/macro.h:26,
                 from udev.h:26,
                 from udevadm-monitor.c:35:
/usr/include/inttypes.h:104:19: note: format string is defined here
  104 | # define PRIu32  "u"
````