### PR TITLE
Do not free a static string

### DIFF
--- a/src/udev/udevadm-hwdb.c
+++ b/src/udev/udevadm-hwdb.c
@@ -621,7 +621,7 @@ static int adm_hwdb(struct udev *udev, int argc, char *argv[]) {
 
         if (update) {
                 char **files, **f;
-                _cleanup_free_ char *hwdb_bin = UDEV_HWDB_BIN;
+                char *hwdb_bin = UDEV_HWDB_BIN;
 
                 trie = new0(struct trie, 1);
                 if (!trie) {

--- a/src/udev/udevadm-hwdb.c
+++ b/src/udev/udevadm-hwdb.c
@@ -621,7 +621,7 @@ static int adm_hwdb(struct udev *udev, int argc, char *argv[]) {
 
         if (update) {
                 char **files, **f;
-                char *hwdb_bin = UDEV_HWDB_BIN;
+                _cleanup_free_ char *hwdb_bin = UDEV_HWDB_BIN;
 
                 trie = new0(struct trie, 1);
                 if (!trie) {

--- a/src/udev/udevadm-hwdb.c
+++ b/src/udev/udevadm-hwdb.c
@@ -621,7 +621,7 @@ static int adm_hwdb(struct udev *udev, int argc, char *argv[]) {
 
         if (update) {
                 char **files, **f;
-                _cleanup_free_ char *hwdb_bin = UDEV_HWDB_BIN;
+                _cleanup_free_ char *hwdb_bin = NULL;
 
                 trie = new0(struct trie, 1);
                 if (!trie) {


### PR DESCRIPTION
In file included from udevadm-hwdb.c:26:
In function ‘freep’,
    inlined from ‘adm_hwdb’ at udevadm-hwdb.c:624:38:
../../src/shared/util.h:289:9: warning: ‘free’ called on a pointer to an unallocated object ‘"/usr/etc/udev/hwdb.bin"’ [-Wfree-nonheap-object]
  289 |         free(*(void**) p);
      |         ^~~~~~~~~~~~~~~~~
../../src/shared/util.h:289:9: warning: ‘free’ called on a pointer to an unallocated object ‘"/usr/etc/udev/hwdb.bin"’ [-Wfree-nonheap-object]