### PR TITLE
Add missing API from 247

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.68])
 AC_INIT([eudev],[3.2.12],[https://github.com/gentoo/eudev/issues])
-AC_SUBST(UDEV_VERSION, 243)
+AC_SUBST(UDEV_VERSION, 251)
 AC_CONFIG_SRCDIR([src/udev/udevd.c])
 
 AC_USE_SYSTEM_EXTENSIONS

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.68])
-AC_INIT([eudev],[3.2.12],[https://github.com/gentoo/eudev/issues])
+AC_INIT([eudev],[3.2.14],[https://github.com/gentoo/eudev/issues])
 AC_SUBST(UDEV_VERSION, 251)
 AC_CONFIG_SRCDIR([src/udev/udevd.c])
 

--- a/src/libudev/libudev-device.c
+++ b/src/libudev/libudev-device.c
@@ -1819,6 +1819,12 @@ _public_ struct udev_list_entry *udev_device_get_tags_list_entry(struct udev_dev
         return udev_list_get_entry(&udev_device->tags_list);
 }
 
+_public_ struct udev_list_entry *udev_device_get_current_tags_list_entry(struct udev_device *udev_device)
+{
+        // TODO: eudev database does not support current tags
+        return udev_device_get_tags_list_entry(udev_device);
+}
+
 /**
  * udev_device_has_tag:
  * @udev_device: udev device
@@ -1840,6 +1846,11 @@ _public_ int udev_device_has_tag(struct udev_device *udev_device, const char *ta
         if (udev_list_entry_get_by_name(list_entry, tag) != NULL)
                 return true;
         return false;
+}
+
+_public_ int udev_device_has_current_tag(struct udev_device *udev_device, const char *tag) {
+        // TODO: eudev database does not support current tags
+        return udev_device_has_tag(udev_device, tag);
 }
 
 #define ENVP_SIZE                        128

--- a/src/libudev/libudev.h
+++ b/src/libudev/libudev.h
@@ -100,6 +100,7 @@ int udev_device_get_is_initialized(struct udev_device *udev_device);
 struct udev_list_entry *udev_device_get_devlinks_list_entry(struct udev_device *udev_device);
 struct udev_list_entry *udev_device_get_properties_list_entry(struct udev_device *udev_device);
 struct udev_list_entry *udev_device_get_tags_list_entry(struct udev_device *udev_device);
+struct udev_list_entry *udev_device_get_current_tags_list_entry(struct udev_device *udev_device);
 struct udev_list_entry *udev_device_get_sysattr_list_entry(struct udev_device *udev_device);
 const char *udev_device_get_property_value(struct udev_device *udev_device, const char *key);
 const char *udev_device_get_driver(struct udev_device *udev_device);
@@ -110,6 +111,7 @@ unsigned long long int udev_device_get_usec_since_initialized(struct udev_device
 const char *udev_device_get_sysattr_value(struct udev_device *udev_device, const char *sysattr);
 int udev_device_set_sysattr_value(struct udev_device *udev_device, const char *sysattr, char *value);
 int udev_device_has_tag(struct udev_device *udev_device, const char *tag);
+int udev_device_has_current_tag(struct udev_device *udev_device, const char *tag);
 
 /*
  * udev_monitor

--- a/src/libudev/libudev.sym
+++ b/src/libudev/libudev.sym
@@ -118,3 +118,9 @@ global:
         udev_queue_flush;
         udev_queue_get_fd;
 } LIBUDEV_199;
+
+LIBUDEV_247 {
+global:
+        udev_device_has_current_tag;
+        udev_device_get_current_tags_list_entry;
+} LIBUDEV_215;


### PR DESCRIPTION
 udev_device_has_current_tag
 udev_device_get_current_tags_list_entry

both are implemented to return all tags, until the current tag concept comes to eudev.

Closes #249 
