### PR TITLE
rules: set uinput group to "input"

### DIFF
--- a/rules/50-udev-default.rules
+++ b/rules/50-udev-default.rules
@@ -27,6 +27,7 @@ KERNEL=="tty[A-Z]*[0-9]|ttymxc[0-9]*|pppox[0-9]*|ircomm[0-9]*|noz[0-9]*|rfcomm[0
 SUBSYSTEM=="mem", KERNEL=="mem|kmem|port", GROUP="kmem", MODE="0640"
 
 SUBSYSTEM=="input", GROUP="input"
+SUBSYSTEM=="misc", KERNEL=="uinput", GROUP="input"
 SUBSYSTEM=="input", KERNEL=="js[0-9]*", MODE="0664"
 
 SUBSYSTEM=="video4linux", GROUP="video"


### PR DESCRIPTION
fix: https://gitlab.alpinelinux.org/alpine/aports/-/issues/15240