### PR TITLE
build: Add missing _CFLAGS variables

### DIFF
--- a/src/libudev/Makefile.am
+++ b/src/libudev/Makefile.am
@@ -31,6 +31,7 @@ libudev_la_SOURCES =\
 
 libudev_la_CFLAGS = \
 	$(AM_CFLAGS) \
+	$(SELINUX_CFLAGS) \
 	-fvisibility=hidden
 
 noinst_HEADERS = \

--- a/src/udev/Makefile.am
+++ b/src/udev/Makefile.am
@@ -64,7 +64,8 @@ include_HEADERS = \
 
 libudev_core_la_CFLAGS = \
 	$(AM_CFLAGS) \
-	$(BLKID_CFLAGS)
+	$(BLKID_CFLAGS) \
+	$(SELINUX_CLFAGS)
 
 libudev_core_la_LIBADD = \
 	$(top_builddir)/src/shared/libudev_shared.la \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -26,6 +26,10 @@ test_libudev_CPPFLAGS = \
 test_udev_SOURCES = \
 	test-udev.c
 
+test_udev_CFLAGS = \
+	$(BLKID_CFLAGS) \
+	$(SELINUX_CFLAGS)
+
 test_udev_LDADD = \
 	$(top_builddir)/src/libudev/libudev-private.la \
 	$(top_builddir)/src/udev/libudev-core.la \
@@ -33,6 +37,8 @@ test_udev_LDADD = \
 	$(SELINUX_LIBS)
 
 if HAVE_KMOD
+test_udev_CFLAGS += \
+	$(KMOD_CFLAGS)
 test_udev_LDADD += \
 	$(KMOD_LIBS)
 endif
@@ -40,7 +46,6 @@ endif
 test_udev_CPPFLAGS = \
 	-I $(top_srcdir)/src/udev \
 	$(AM_CPPFLAGS)
-
 
 TESTS = \
 	udev-test.pl \


### PR DESCRIPTION
This can help with cross-compiling.

Gentoo bug: https://bugs.gentoo.org/771705