### PR TITLE
Dynamically get the udevadm hwdb files with a path variable

### DIFF
--- a/man/udev.7
+++ b/man/udev.7
@@ -34,7 +34,7 @@ All device information udev processes is stored in the udev database and sent ou
 .SH "RULES FILES"
 .PP
 The udev rules are read from the files located in the system rules directory
-/lib/udev/rules\&.d (additionally /usr/lib/udev/rules\&.d when built with --enable-split-usr), the volatile runtime directory
+/lib/udev/rules\&.d, the volatile runtime directory
 /run/udev/rules\&.d
 and the local administration directory
 /etc/udev/rules\&.d\&. All rules files are collectively sorted and processed in lexical order, regardless of the directories in which they live\&. However, files with identical filenames replace each other\&. Files in
@@ -42,7 +42,7 @@ and the local administration directory
 have the highest priority, files in
 /run
 take precedence over files with the same name in
-/lib (or /usr/lib)\&. This can be used to override a system\-supplied rules file with a local file if needed; a symlink in
+/lib\&. This can be used to override a system\-supplied rules file with a local file if needed; a symlink in
 /etc
 with the same name as a rules file in
 /lib, pointing to
@@ -535,13 +535,17 @@ character itself\&.
 The hwdb files are read from the files located in the system hwdb directory
 /usr/lib/udev/hwdb\&.d, the volatile runtime directory
 /run/udev/hwdb\&.d
-and the local administration directory
-/etc/udev/hwdb\&.d\&. All hwdb files are collectively sorted and processed in lexical order, regardless of the directories in which they live\&. However, files with identical filenames replace each other\&. Files in
+the local administration directory
+/etc/udev/hwdb\&.d, and any other directory in the
+\fBUDEV_HWDB_PATH\fR
+search path variable\&. All hwdb files are collectively sorted and processed in lexical order, regardless of the directories in which they live\&. However, files with identical filenames replace each other\&. Files in
 /etc
 have the highest priority, files in
 /run
 take precedence over files with the same name in
-/usr/lib\&. This can be used to override a system\-supplied hwdb file with a local file if needed; a symlink in
+/usr/lib, and the content of
+\fBUDEV_HWDB_PATH\fR
+comes last\&. This order can be used to override a system\-supplied hwdb file with a local file if needed; a symlink in
 /etc
 with the same name as a hwdb file in
 /usr/lib, pointing to

--- a/man/udev.xml
+++ b/man/udev.xml
@@ -736,12 +736,15 @@
       <para>The hwdb files are read from the files located in the
       system hwdb directory <filename>/usr/lib/udev/hwdb.d</filename>,
       the volatile runtime directory <filename>/run/udev/hwdb.d</filename>
-      and the local administration directory <filename>/etc/udev/hwdb.d</filename>.
+      the local administration directory <filename>/etc/udev/hwdb.d</filename>,
+      and any other directory in the <envar>UDEV_HWDB_PATH</envar> search path variable.
       All hwdb files are collectively sorted and processed in lexical order,
       regardless of the directories in which they live. However, files with
       identical filenames replace each other. Files in <filename>/etc</filename>
-      have the highest priority, files in <filename>/run</filename> take precedence
-      over files with the same name in <filename>/usr/lib</filename>. This can be
+      have the highest priority, files in <filename>/run</filename>
+      take precedence over files with the same name in
+      <filename>/usr/lib</filename>, and the content of
+      <envar>UDEV_HWDB_PATH</envar> comes last. This order can be
       used to override a system-supplied hwdb file with a local file if needed;
       a symlink in <filename>/etc</filename> with the same name as a hwdb file in
       <filename>/usr/lib</filename>, pointing to <filename>/dev/null</filename>,

--- a/man/udevadm.8
+++ b/man/udevadm.8
@@ -356,7 +356,11 @@ Maintain the hardware database index in
 .PP
 \fB\-u\fR, \fB\-\-update\fR
 .RS 4
-Compile the hardware database information located in /usr/lib/udev/hwdb\&.d/, /etc/udev/hwdb\&.d/ and store it in
+Compile the hardware database information located in
+/etc/udev/hwdb\&.d/,
+/usr/lib/udev/hwdb\&.d/, and under the
+\fBUDEV_HWDB_PATH\fR
+path environment variable, and store it in
 /etc/udev/hwdb\&.bin\&. This should be done after any update to the source files; it will not be called automatically\&. The running udev daemon will detect a new database on its own and does not need to be notified about it\&.
 .RE
 .PP

--- a/man/udevadm.xml
+++ b/man/udevadm.xml
@@ -521,11 +521,16 @@
           <term><option>-u</option></term>
           <term><option>--update</option></term>
           <listitem>
-            <para>Compile the hardware database information located in /usr/lib/udev/hwdb.d/,
-            /etc/udev/hwdb.d/ and store it in <filename>/etc/udev/hwdb.bin</filename>. This should be done after
-            any update to the source files; it will not be called automatically. The running
-            udev daemon will detect a new database on its own and does not need to be
-            notified about it.</para>
+            <para>Compile the hardware database information located in
+            <filename>/etc/udev/hwdb.d/</filename>,
+            <filename>/usr/lib/udev/hwdb.d/</filename>, and under the
+            <envar>UDEV_HWDB_PATH</envar> path environment variable,
+            and store it in
+            <filename>/etc/udev/hwdb.bin</filename>. This should be
+            done after any update to the source files; it will not be
+            called automatically. The running udev daemon will detect
+            a new database on its own and does not need to be notified
+            about it.</para>
           </listitem>
         </varlistentry>
         <varlistentry>

--- a/src/shared/conf-files.h
+++ b/src/shared/conf-files.h
@@ -23,3 +23,4 @@
 #include "macro.h"
 
 int conf_files_list_strv(char ***strv, const char *suffix, const char *root, const char* const* dirs);
+int conf_files_list_strv_path(char ***strv, const char *suffix, const char *root, const char* path);

--- a/src/udev/udevadm-hwdb.c
+++ b/src/udev/udevadm-hwdb.c
@@ -688,14 +688,13 @@ static int adm_hwdb(struct udev *udev, int argc, char *argv[]) {
                 }
                 trie->nodes_count++;
 
-                char *conf_file_path = list_conf_file_path ();
+                _cleanup_free_ char *conf_file_path = list_conf_file_path ();
                 if (conf_file_path == NULL) {
                         rc = EXIT_FAILURE;
                         goto out;
                 }
                 err = conf_files_list_strv_path(&files, ".hwdb", root,
                                                 conf_file_path);
-                free (conf_file_path);
                 if (err < 0) {
                         log_error_errno(err, "failed to enumerate hwdb files: %m");
                         rc = EXIT_FAILURE;


### PR DESCRIPTION
Dear eudev developers,

It would be useful for a Guix package to let udevadm hwdb --update collect hwdb files from different places in the file system. Usually, this is done with a search path. Here I introduce UDEV_HWDB_PATH, which is searched when compiling hwdb.bin, for hwdb files, in addition to /etc/udev/hwdb.d and /lib/udev/hwdb.d.

What do you think?

Best regards,

Vivien Kraus