### PR TITLE
Add a generic --output argument to udevadm hwdb

### DIFF
--- a/man/udev.7
+++ b/man/udev.7
@@ -34,7 +34,7 @@ All device information udev processes is stored in the udev database and sent ou
 .SH "RULES FILES"
 .PP
 The udev rules are read from the files located in the system rules directory
-/lib/udev/rules\&.d (additionally /usr/lib/udev/rules\&.d when built with --enable-split-usr), the volatile runtime directory
+/lib/udev/rules\&.d, the volatile runtime directory
 /run/udev/rules\&.d
 and the local administration directory
 /etc/udev/rules\&.d\&. All rules files are collectively sorted and processed in lexical order, regardless of the directories in which they live\&. However, files with identical filenames replace each other\&. Files in
@@ -42,7 +42,7 @@ and the local administration directory
 have the highest priority, files in
 /run
 take precedence over files with the same name in
-/lib (or /usr/lib)\&. This can be used to override a system\-supplied rules file with a local file if needed; a symlink in
+/lib\&. This can be used to override a system\-supplied rules file with a local file if needed; a symlink in
 /etc
 with the same name as a rules file in
 /lib, pointing to
@@ -560,7 +560,9 @@ The content of all hwdb files is read by
 and compiled to a binary database located at
 /etc/udev/hwdb\&.bin, or alternatively
 /usr/lib/udev/hwdb\&.bin
-if you want ship the compiled database in an immutable image\&. During runtime only the binary database is used\&.
+if you want ship the compiled database in an immutable image by using
+\fB\-\-usr\fR, or anywhere on the system by using
+\fB\-\-output\fR\&. During runtime only the binary database is used\&.
 .SH "SEE ALSO"
 .PP
 \fBudevd\fR(8),

--- a/man/udev.xml
+++ b/man/udev.xml
@@ -765,7 +765,7 @@
       <citerefentry><refentrytitle>udevadm</refentrytitle><manvolnum>8</manvolnum></citerefentry>
       and compiled to a binary database located at <filename>/etc/udev/hwdb.bin</filename>,
       or alternatively <filename>/usr/lib/udev/hwdb.bin</filename> if you want ship the compiled
-      database in an immutable image.
+      database in an immutable image by using <option>--usr</option>, or anywhere on the system by using <option>--output</option>.
       During runtime only the binary database is used.</para>
   </refsect1>
 

--- a/man/udevadm.8
+++ b/man/udevadm.8
@@ -380,6 +380,11 @@ Query the database with a modalias string, and print the retrieved properties\&.
 Alternative root path in the file system for reading and writing files\&.
 .RE
 .PP
+\fB\-o\fR, \fB\-\-output=\fR\fB\fIstring\fR\fR
+.RS 4
+Specify the exact location where to write the compiled database\&.
+.RE
+.PP
 \fB\-h\fR, \fB\-\-help\fR
 .RS 4
 Print help text\&.

--- a/man/udevadm.xml
+++ b/man/udevadm.xml
@@ -553,6 +553,13 @@
           </listitem>
         </varlistentry>
         <varlistentry>
+          <term><option>-o</option></term>
+          <term><option>--output=<replaceable>string</replaceable></option></term>
+          <listitem>
+            <para>Specify the exact location where to write the compiled database.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
           <term><option>-h</option></term>
           <term><option>--help</option></term>
           <listitem>

--- a/src/udev/udevadm-hwdb.c
+++ b/src/udev/udevadm-hwdb.c
@@ -564,6 +564,7 @@ static int import_file(struct udev *udev, struct trie *trie, const char *filenam
 static void help(void) {
         printf("Usage: udevadm hwdb OPTIONS\n"
                "  -u,--update          update the hardware database\n"
+               "  -o,--output=.../hwdb.bin generate in .../hwdb.bin instead of /etc/udev/hwdb.bin\n"
                "  --usr                generate in " UDEV_LIBEXEC_DIR " instead of /etc/udev\n"
                "  -t,--test=MODALIAS   query database and print result\n"
                "  -r,--root=PATH       alternative root path in the filesystem\n"
@@ -578,6 +579,7 @@ static int adm_hwdb(struct udev *udev, int argc, char *argv[]) {
         static const struct option options[] = {
                 { "update", no_argument,       NULL, 'u' },
                 { "usr",    no_argument,       NULL, ARG_USR },
+                { "output", required_argument, NULL, 'o' },
                 { "test",   required_argument, NULL, 't' },
                 { "root",   required_argument, NULL, 'r' },
                 { "help",   no_argument,       NULL, 'h' },
@@ -585,19 +587,37 @@ static int adm_hwdb(struct udev *udev, int argc, char *argv[]) {
         };
         const char *test = NULL;
         const char *root = "";
-        const char *hwdb_bin_dir = "/etc/udev";
         bool update = false;
         struct trie *trie = NULL;
         int err, c;
         int rc = EXIT_SUCCESS;
 
-        while ((c = getopt_long(argc, argv, "ut:r:h", options, NULL)) >= 0)
+        _cleanup_free_ char *hwdb_bin = strdup("/etc/udev/hwdb.bin");
+        if (hwdb_bin == NULL) {
+                rc = EXIT_FAILURE;
+                goto out;
+        }
+
+        while ((c = getopt_long(argc, argv, "uo:t:r:h", options, NULL)) >= 0)
                 switch(c) {
                 case 'u':
                         update = true;
                         break;
                 case ARG_USR:
-                        hwdb_bin_dir = UDEV_LIBEXEC_DIR;
+                        free(hwdb_bin);
+                        hwdb_bin = strdup(UDEV_LIBEXEC_DIR "/hwdb.bin");
+                        if (hwdb_bin == NULL) {
+                                rc = EXIT_FAILURE;
+                                goto out;
+                        }
+                        break;
+                case 'o':
+                        free(hwdb_bin);
+                        hwdb_bin = strdup(optarg);
+                        if (hwdb_bin == NULL) {
+                                rc = EXIT_FAILURE;
+                                goto out;
+                        }
                         break;
                 case 't':
                         test = optarg;
@@ -621,7 +641,20 @@ static int adm_hwdb(struct udev *udev, int argc, char *argv[]) {
 
         if (update) {
                 char **files, **f;
-                _cleanup_free_ char *hwdb_bin = NULL;
+
+                if (strlen(root)) {
+                        /* --root has been specified, prepend it to
+                           the hwdb.bin destination file. */
+                        char *full_hwdb_bin = strjoin(root, "/", hwdb_bin, NULL);
+                        /* Do nothing if no --root, so that hwdb_bin
+                           may still be relative. */
+                        if (full_hwdb_bin == NULL) {
+                          rc = EXIT_FAILURE;
+                          goto out;
+                        }
+                        free (hwdb_bin);
+                        hwdb_bin = full_hwdb_bin;
+                }
 
                 trie = new0(struct trie, 1);
                 if (!trie) {
@@ -672,7 +705,6 @@ static int adm_hwdb(struct udev *udev, int argc, char *argv[]) {
                 log_debug("strings dedup'ed: %8zu bytes (%8zu)",
                           trie->strings->dedup_len, trie->strings->dedup_count);
 
-                hwdb_bin = strjoin(root, "/", hwdb_bin_dir, "/hwdb.bin", NULL);
                 if (!hwdb_bin) {
                         rc = EXIT_FAILURE;
                         goto out;


### PR DESCRIPTION
Dear eudev developers,

In Guix, every package is installed in a separate "/usr" prefix. For instance, eudev is installed in "/usr-a/" and upower in "/usr-b/" (except it’s actually "/gnu/store/xxx-eudev-version" and "/gnu/store/yyy-upower-version", whatever). If I want to compile the hwdb database and write it to "/usr-b/lib/udev/hwdb.bin" (with "--usr"), the "--root" argument is insufficient. If I compile with --root=/usr-b, I will end up with "/usr-b/usr-a/lib/udev/hwdb.bin".

I think it would be better to let udevadm hwdb write to an arbitrary file.

What do you think?

Best regards,

Vivien