### PR TITLE
Let libudev find hwdb.bin under UDEV_HWDB_BIN

### DIFF
--- a/man/udev.7
+++ b/man/udev.7
@@ -34,7 +34,7 @@ All device information udev processes is stored in the udev database and sent ou
 .SH "RULES FILES"
 .PP
 The udev rules are read from the files located in the system rules directory
-/lib/udev/rules\&.d (additionally /usr/lib/udev/rules\&.d when built with --enable-split-usr), the volatile runtime directory
+/lib/udev/rules\&.d, the volatile runtime directory
 /run/udev/rules\&.d
 and the local administration directory
 /etc/udev/rules\&.d\&. All rules files are collectively sorted and processed in lexical order, regardless of the directories in which they live\&. However, files with identical filenames replace each other\&. Files in
@@ -42,7 +42,7 @@ and the local administration directory
 have the highest priority, files in
 /run
 take precedence over files with the same name in
-/lib (or /usr/lib)\&. This can be used to override a system\-supplied rules file with a local file if needed; a symlink in
+/lib\&. This can be used to override a system\-supplied rules file with a local file if needed; a symlink in
 /etc
 with the same name as a rules file in
 /lib, pointing to
@@ -560,7 +560,9 @@ The content of all hwdb files is read by
 and compiled to a binary database located at
 /etc/udev/hwdb\&.bin, or alternatively
 /usr/lib/udev/hwdb\&.bin
-if you want ship the compiled database in an immutable image\&. During runtime only the binary database is used\&.
+if you want ship the compiled database in an immutable image\&. If
+\fBUDEV_HWDB_BIN\fR
+is set at run\-time, and its value identifies a file in the file system, then the binary database located under this name will be used\&. During runtime only the binary database is used\&.
 .SH "SEE ALSO"
 .PP
 \fBudevd\fR(8),

--- a/man/udev.xml
+++ b/man/udev.xml
@@ -765,7 +765,9 @@
       <citerefentry><refentrytitle>udevadm</refentrytitle><manvolnum>8</manvolnum></citerefentry>
       and compiled to a binary database located at <filename>/etc/udev/hwdb.bin</filename>,
       or alternatively <filename>/usr/lib/udev/hwdb.bin</filename> if you want ship the compiled
-      database in an immutable image.
+      database in an immutable image. If <envar>UDEV_HWDB_BIN</envar>
+      is set at run-time, and its value identifies a file in the file system, then the binary
+      database located under this name will be used.
       During runtime only the binary database is used.</para>
   </refsect1>
 

--- a/src/libudev/libudev.h
+++ b/src/libudev/libudev.h
@@ -185,7 +185,9 @@ struct udev_list_entry *udev_queue_get_queued_list_entry(struct udev_queue *udev
 /*
  *  udev_hwdb
  *
- *  access to the static hardware properties database
+ *  access to the static hardware properties database; the database to
+ *  use can be overriden by setting the UDEV_HWDB_BIN environment
+ *  variable to its file name
  */
 struct udev_hwdb;
 struct udev_hwdb *udev_hwdb_new(struct udev *udev);


### PR DESCRIPTION
Dear eudev developers,

It is not very convenient that libudev can only use /etc/udev/hwdb.bin or <prefix>/lib/udev/hwdb.bin. For Guix, we would like that the hwdb.bin file would be compiled for every used combination of hwdb-providing packages, and then let different users choose the file to use at run-time. The minimum that would work would be to add a single (absolute) file name under UDEV_HWDB_BIN, so that libudev would try that file first (and then, fall back to /etc and <prefix>/lib). This is NOT a path variable. Libudev cannot use multiple hwdb.bin files anyway, so there is no need for a path.

The list of files to try for hwdb.bin is now dynamic, and so we should account for malloc failures. However, `udev_hwdb_validate` is not supposed to be able to fail. So, I think it should be OK to store the list of files to try in the struct udev_hwdb instance.

What do you think?

Best regards,

Vivien