### PR TITLE
78-sound-card.rules: Import ID_PATH early

### DIFF
--- a/rules/78-sound-card.rules
+++ b/rules/78-sound-card.rules
@@ -38,6 +38,8 @@ KERNEL!="card*", GOTO="sound_end"
 ENV{SOUND_INITIALIZED}="1"
 
 IMPORT{builtin}="hwdb"
+IMPORT{builtin}="path_id"
+
 SUBSYSTEMS=="usb", IMPORT{builtin}="usb_id"
 SUBSYSTEMS=="usb", GOTO="skip_pci"
 
@@ -61,8 +63,6 @@ LABEL="skip_pci"
 # USB and firewire.
 ENV{ID_SERIAL}=="?*", ENV{ID_USB_INTERFACE_NUM}=="?*", ENV{ID_ID}="$env{ID_BUS}-$env{ID_SERIAL}-$env{ID_USB_INTERFACE_NUM}"
 ENV{ID_SERIAL}=="?*", ENV{ID_USB_INTERFACE_NUM}=="", ENV{ID_ID}="$env{ID_BUS}-$env{ID_SERIAL}"
-
-IMPORT{builtin}="path_id"
 
 # The values used here for $SOUND_FORM_FACTOR and $SOUND_CLASS should be kept
 # in sync with those defined for PulseAudio's src/pulse/proplist.h


### PR DESCRIPTION
Pipewire requires ID_PATH to use the same device names as with systemd's udev. Some rules, such as the ones in asahi-audio [1] use those names, and fail if they don't match [2].

On systemd's udev this is instead imported in 71-seat.rules, which we don't have.

[1]: https://github.com/AsahiLinux/asahi-audio
[2]: https://github.com/AsahiLinux/asahi-audio/issues/16