### PR TITLE
udev/path_id: introduce support for NVMe devices

### DIFF
--- a/src/udev/udev-builtin-path_id.c
+++ b/src/udev/udev-builtin-path_id.c
@@ -636,6 +636,15 @@ static int builtin_path_id(struct udev_device *dev, int argc __attribute__((unus
                         parent = skip_subsystem(parent, "scm");
                         supported_transport = true;
                         supported_parent = true;
+                } else if (streq(subsys, "nvme")) {
+                        const char *nsid = udev_device_get_sysattr_value(dev, "nsid");
+
+                        if (nsid) {
+                                path_prepend(&path, "nvme-%s", nsid);
+                                parent = skip_subsystem(parent, "nvme");
+                                supported_parent = true;
+                                supported_transport = true;
+                        }
                 }
 
                 parent = udev_device_get_parent(parent);


### PR DESCRIPTION
This is a [commit from upstream](https://github.com/systemd/systemd/commit/b4c6f71b827d41a4af8007b735edf21ef7609f99) to add /dev/disk/by-path symlinks for nvme devices. I could not get the original commit to apply (at all), so I copied the changes manually and retained the original commit metadata. I verified the changes with an nvme m.2 storage device. Original commit message is as-is below:

```
udev/path_id: introduce support for NVMe devices

This appends the nvme name and namespace identifier attribute the the
PCI path for by-path links. Symlinks like the following are now present:

lrwxrwxrwx. 1 root root 13 Sep 16 12:12 pci-0000:01:00.0-nvme-1 -> ../../nvme0n1
lrwxrwxrwx. 1 root root 15 Sep 16 12:12 pci-0000:01:00.0-nvme-1-part1 -> ../../nvme0n1p1

Cc: Michal Sekletar <sekletar.m@gmail.com>
Signed-off-by: Keith Busch <keith.busch@intel.com>
```