### PR TITLE
80-net-name-slot.rules: consider ID_NET_NAME_MAC as a name

### DIFF
--- a/rules/80-net-name-slot.rules
+++ b/rules/80-net-name-slot.rules
@@ -10,5 +10,6 @@ ENV{net.ifnames}=="0", GOTO="net_name_slot_end"
 NAME=="", ENV{ID_NET_NAME_ONBOARD}!="", NAME="$env{ID_NET_NAME_ONBOARD}"
 NAME=="", ENV{ID_NET_NAME_SLOT}!="", NAME="$env{ID_NET_NAME_SLOT}"
 NAME=="", ENV{ID_NET_NAME_PATH}!="", NAME="$env{ID_NET_NAME_PATH}"
+NAME=="", ENV{ID_NET_NAME_MAC}!="", NAME="$env{ID_NET_NAME_MAC}"
 
 LABEL="net_name_slot_end"


### PR DESCRIPTION
If nothing else is available, even a MAC name is better than nothing.