### PR TITLE
fix typos

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -46,7 +46,7 @@ want to try:
 	(drop into editor and squash commits)	# note the ^ at the end!
 	(exit editor and fix commit message)
 
-Alternatively, you can cherry-pick those commits into another prestine branch:
+Alternatively, you can cherry-pick those commits into another pristine branch:
 
 	... its good to go! ....
 
@@ -72,7 +72,7 @@ You can delete a remote branch by doing
 
 3. Your commit message should conform to the following standard:
 
-	file/changed: Concice and complete statement of the purpose
+	file/changed: Concise and complete statement of the purpose
 
 	This is the body of the commit message.  The line above is the
 	summary.  The summary should be no more than 72 chars long.  The

--- a/src/dmi_memory_id/dmi_memory_id.c
+++ b/src/dmi_memory_id/dmi_memory_id.c
@@ -90,7 +90,7 @@ static bool verify_checksum(const uint8_t *buf, size_t len) {
 }
 
 /*
- * Type-independant Stuff
+ * Type-independent Stuff
  */
 
 static const char *dmi_string(const struct dmi_header *dm, uint8_t s) {

--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -1521,7 +1521,7 @@ bool in_initrd(void) {
          *
          * The second check is extra paranoia, since misdetecting an
          * initrd can have bad bad consequences due the initrd
-         * emptying when transititioning to the main systemd.
+         * emptying when transitioning to the main systemd.
          */
 
         saved = access("/etc/initrd-release", F_OK) >= 0 &&

--- a/src/udev/udev-event.c
+++ b/src/udev/udev-event.c
@@ -845,7 +845,7 @@ static int rename_netif_dev_fromname_toname(struct udev_device *dev __attribute_
         r = ioctl(sk, SIOCSIFNAME, &ifr_tmp);
                 log_info("Temporarily renamed network interface %s to %s\n", ifr_tmp.ifr_name, ifr_tmp.ifr_newname);
 
-        /* we have changed our name so in subsequents tries i should rename my temporal name to the wanted one */
+        /* we have changed our name so in subsequent tries i should rename my temporal name to the wanted one */
         strscpy(ifr.ifr_name, IFNAMSIZ, ifr_tmp.ifr_newname);
 
         r = -errno;


### PR DESCRIPTION
@bbonev 

I presume an external origin of the files under hwdb and rules.

WON'T FIX (typo in commit name)

```
$ grep -nr objcet eudev
eudev/NOTES:13: * We skip 'udevd: pass a Manager objcet to event handlers'
$ 
```