### PR TITLE
build: Add libtool as build-dependency for Alpine

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -32,6 +32,7 @@ the Linux distribution:
       libxslt \
       linux-headers \
       perl \
+      libtool \
       util-linux-dev
 
 


### PR DESCRIPTION
Noticed libtool was missing as a build-dependency for Alpine Linux. Without it, the `./autogen.sh` step would complain about `error: Libtool library used but 'LIBTOOL' is undefined`. This PR just adds libtool to the list of dependencies.