### PR TITLE
random-util.c: sync dev_urandom implementation to systemd-udev

### DIFF
--- a/src/shared/missing.h
+++ b/src/shared/missing.h
@@ -79,6 +79,10 @@ static inline int getrandom(void *buffer, size_t count, unsigned flags) {
 #define GRND_RANDOM 0x0002
 #endif
 
+#ifndef GRND_INSECURE
+#define GRND_INSECURE 0x0004
+#endif
+
 #ifndef BTRFS_IOCTL_MAGIC
 #define BTRFS_IOCTL_MAGIC 0x94
 #endif


### PR DESCRIPTION
Current dev_urandom() assumes that reading /dev/urandom will never block regardless if the random pool is fully initialized or not.
This assumption is no longer applicable since linux kerrnel enforces the /dev/urandom entropy initialization from v5.18-rc2 with the commit:
48bff1053c17 ("random: opportunistically initialize on /dev/urandom reads").

With this, when we use the linux v5.18-rc2 or later, dev_urandom() will block if enough random pool is not supplied. It causes the boot delay, typically 1024msec(4msec * 256 = 1024msec) delay to fill the 256 bits entropy for the case CONFIG_HZ=250.

To prevent this boot delay, this commit syncs dev_urandom() implementation to the systemd-udev.
The systemd-udev implementation of reading /dev/urandom is as follows.
 - Try to get random with calling getrandom(GRND_INSECURE)
 - If kernel does not support GRND_INSECURE, fallback to GRND_NONBLOCK
 - If enough entropy is not supplied, fallback to reading /dev/urandom, this will block when the kernel version is v5.18-rc2 or later

With this modification, dev_urandom() tries not to block as much as possible.

This modification still keeps the backword compatibility, dev_random() will never block if the commit(48bff1053c17) is not applied to the linux kernel, the behavior is same as before in this case.