### PR TITLE
udev/Makefile.am:  fix wrong condition for /usr type check in install-exec-hook

### DIFF
--- a/src/udev/Makefile.am
+++ b/src/udev/Makefile.am
@@ -136,7 +136,7 @@ CLEANFILES += \
 
 # install udevadm symlink in sbindir
 install-exec-hook:
-	test "$(bindir)" = "$(sbindir)" || \
+	test "$(bindir)" != "$(sbindir)" || \
 		$(LN_S) -f $(bindir)/udevadm $(DESTDIR)$(sbindir)/udevadm
 
 uninstall-hook:


### PR DESCRIPTION
Wrong condition  in install-exec-hook leads to eudev installation failure in merged /usr systems and to lack of link under /sbin in separate /usr systems.