### PR TITLE
udev-rules: Fix compile errors with `-DDEBUG=1`

### DIFF
--- a/src/udev/udev-rules.c
+++ b/src/udev/udev-rules.c
@@ -326,8 +326,8 @@ static void dump_token(struct udev_rules *rules, struct token *token) {
         enum token_type type = token->type;
         enum operation_type op = token->key.op;
         enum string_glob_type glob = token->key.glob;
-        const char *value = str(rules, token->key.value_off);
-        const char *attr = &rules->buf[token->key.attr_off];
+        const char *value = rules_str(rules, token->key.value_off);
+        const char *attr = rules_str(rules, token->key.attr_off);
 
         switch (type) {
         case TK_RULE:
@@ -337,9 +337,9 @@ static void dump_token(struct udev_rules *rules, struct token *token) {
                         unsigned int idx = (tk_ptr - tks_ptr) / sizeof(struct token);
 
                         log_debug("* RULE %s:%u, token: %u, count: %u, label: '%s'",
-                                  &rules->buf[token->rule.filename_off], token->rule.filename_line,
+                                  rules_str(rules, token->rule.filename_off), token->rule.filename_line,
                                   idx, token->rule.token_count,
-                                  &rules->buf[token->rule.label_off]);
+                                  rules_str(rules, token->rule.label_off));
                         break;
                 }
         case TK_M_ACTION:
@@ -436,11 +436,11 @@ static void dump_token(struct udev_rules *rules, struct token *token) {
 static void dump_rules(struct udev_rules *rules) {
         unsigned int i;
 
-        log_debug("dumping %u (%zu bytes) tokens, %u (%zu bytes) strings",
+        log_debug("dumping %u tokens (%zu bytes), %zu strings (%zu bytes)",
                   rules->token_cur,
                   rules->token_cur * sizeof(struct token),
-                  rules->buf_count,
-                  rules->buf_cur);
+                  rules->strbuf->in_count,
+                  rules->strbuf->in_len);
         for (i = 0; i < rules->token_cur; i++)
                 dump_token(rules, &rules->tokens[i]);
 }


### PR DESCRIPTION
`DEBUG` turns on some - apparently untested - code that causes compile errors (see linked GitHub issue). Fixing up the unfinished migration to `strbuf`s solves this problem.

Fixes: 915bf0f60fa7 ("udev: use strbuf to store rules strings")
Closes: #287